### PR TITLE
Add video browsing components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
+# Contact Book with Video Browser
 
+This Angular project now includes a simple video browser. Navigate to `/videos` to see a list of example videos. Clicking a video opens the details page.
+
+Sample data is loaded from `src/assets/videos.json` using `VideoService`.

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -2,12 +2,16 @@ import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { AddContactComponent } from './add-contact/add-contact.component';
 import { DisplayContactComponent } from './display-contact/display-contact.component';
+import { VideoListComponent } from './video-list/video-list.component';
+import { VideoDetailsComponent } from './video-details/video-details.component';
 
 
 const routes: Routes = [
   {path:"",redirectTo:'addContact',pathMatch:'full'},
   {path:'addContact',component:AddContactComponent},
   {path:'showContacts',component:DisplayContactComponent},
+  {path:'videos',component:VideoListComponent},
+  {path:'video/:id',component:VideoDetailsComponent},
   {path:'**',redirectTo:'addContact',pathMatch:'full'}
 ];
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -7,12 +7,16 @@ import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { AddContactComponent } from './add-contact/add-contact.component';
 import { DisplayContactComponent } from './display-contact/display-contact.component';
+import { VideoListComponent } from './video-list/video-list.component';
+import { VideoDetailsComponent } from './video-details/video-details.component';
 
 @NgModule({
   declarations: [
     AppComponent,
     AddContactComponent,
-    DisplayContactComponent
+    DisplayContactComponent,
+    VideoListComponent,
+    VideoDetailsComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/ivideo.ts
+++ b/src/app/ivideo.ts
@@ -1,0 +1,7 @@
+export interface IVideo {
+  id: number;
+  title: string;
+  description: string;
+  thumbnail: string;
+  src: string;
+}

--- a/src/app/video-details/video-details.component.css
+++ b/src/app/video-details/video-details.component.css
@@ -1,0 +1,7 @@
+.video-details {
+  text-align: center;
+}
+.thumb {
+  width: 300px;
+  height: auto;
+}

--- a/src/app/video-details/video-details.component.html
+++ b/src/app/video-details/video-details.component.html
@@ -1,0 +1,9 @@
+<div *ngIf="video" class="video-details">
+  <h2>{{video.title}}</h2>
+  <img [src]="video.thumbnail" alt="{{video.title}}" class="thumb">
+  <p>{{video.description}}</p>
+  <video width="400" controls>
+    <source [src]="video.src" type="video/mp4">
+    Your browser does not support the video tag.
+  </video>
+</div>

--- a/src/app/video-details/video-details.component.spec.ts
+++ b/src/app/video-details/video-details.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { VideoDetailsComponent } from './video-details.component';
+
+describe('VideoDetailsComponent', () => {
+  let component: VideoDetailsComponent;
+  let fixture: ComponentFixture<VideoDetailsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ VideoDetailsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(VideoDetailsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/video-details/video-details.component.ts
+++ b/src/app/video-details/video-details.component.ts
@@ -1,0 +1,20 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { IVideo } from '../ivideo';
+import { VideoService } from '../video.service';
+
+@Component({
+  selector: 'app-video-details',
+  templateUrl: './video-details.component.html',
+  styleUrls: ['./video-details.component.css']
+})
+export class VideoDetailsComponent implements OnInit {
+  video: IVideo | undefined;
+
+  constructor(private route: ActivatedRoute, private videoService: VideoService) { }
+
+  ngOnInit() {
+    const id = Number(this.route.snapshot.paramMap.get('id'));
+    this.videoService.getVideo(id).subscribe(v => this.video = v);
+  }
+}

--- a/src/app/video-list/video-list.component.css
+++ b/src/app/video-list/video-list.component.css
@@ -1,0 +1,13 @@
+.video-list {
+  display: flex;
+  flex-wrap: wrap;
+}
+.video-item {
+  margin: 10px;
+  width: 200px;
+  text-align: center;
+}
+.thumb {
+  width: 100%;
+  height: auto;
+}

--- a/src/app/video-list/video-list.component.html
+++ b/src/app/video-list/video-list.component.html
@@ -1,0 +1,8 @@
+<div class="video-list">
+  <div class="video-item" *ngFor="let video of videos">
+    <a [routerLink]="['/video', video.id]">
+      <img [src]="video.thumbnail" alt="{{video.title}}" class="thumb">
+      <h3>{{video.title}}</h3>
+    </a>
+  </div>
+</div>

--- a/src/app/video-list/video-list.component.spec.ts
+++ b/src/app/video-list/video-list.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { VideoListComponent } from './video-list.component';
+
+describe('VideoListComponent', () => {
+  let component: VideoListComponent;
+  let fixture: ComponentFixture<VideoListComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ VideoListComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(VideoListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/video-list/video-list.component.ts
+++ b/src/app/video-list/video-list.component.ts
@@ -1,0 +1,18 @@
+import { Component, OnInit } from '@angular/core';
+import { IVideo } from '../ivideo';
+import { VideoService } from '../video.service';
+
+@Component({
+  selector: 'app-video-list',
+  templateUrl: './video-list.component.html',
+  styleUrls: ['./video-list.component.css']
+})
+export class VideoListComponent implements OnInit {
+  videos: IVideo[] = [];
+
+  constructor(private videoService: VideoService) { }
+
+  ngOnInit() {
+    this.videoService.getVideos().subscribe(data => this.videos = data);
+  }
+}

--- a/src/app/video.service.ts
+++ b/src/app/video.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { IVideo } from './ivideo';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class VideoService {
+  private videosUrl = 'assets/videos.json';
+
+  constructor(private http: HttpClient) { }
+
+  getVideos(): Observable<IVideo[]> {
+    return this.http.get<IVideo[]>(this.videosUrl);
+  }
+
+  getVideo(id: number): Observable<IVideo | undefined> {
+    return this.getVideos().pipe(
+      map(videos => videos.find(video => video.id === id))
+    );
+  }
+}

--- a/src/assets/videos.json
+++ b/src/assets/videos.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": 1,
+    "title": "Sample Video 1",
+    "description": "First sample video for testing purposes.",
+    "thumbnail": "https://via.placeholder.com/300x170?text=Video+1",
+    "src": "https://example.com/video1.mp4"
+  },
+  {
+    "id": 2,
+    "title": "Sample Video 2",
+    "description": "Second sample video for testing purposes.",
+    "thumbnail": "https://via.placeholder.com/300x170?text=Video+2",
+    "src": "https://example.com/video2.mp4"
+  }
+]


### PR DESCRIPTION
## Summary
- create `VideoService` and `IVideo` interface
- add `video-list` and `video-details` components
- wire up routes for videos
- include sample video JSON data
- update README with feature usage

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_683ff3416e74832c9f6d3a1c9754608f